### PR TITLE
Update CI to be more friendly for self-hosted runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2.1
 
+executors:
+  # For running on CircleCI's self-hosted runners
+  runner:
+    machine: true
+    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    # For running on CircleCI's compute resources you would replace the above with the following for all jobs:
+    # docker:
+    #   - image: cimg/python:3.11.4
+
 # Define custom commands for this config
 # See https://circleci.com/docs/reusing-config/#authoring-reusable-commands
 commands:
@@ -33,18 +42,20 @@ commands:
 # See: https://circleci.com/docs/jobs-steps/
 jobs:
   install-build:
-    # For running on CircleCI's self-hosted runners
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
-    # For running on CircleCI's compute resources you would replace the above with the following for all jobs:
-    # docker:
-    #   - image: cimg/python:3.11.4
+    executor: runner
     steps:
       - checkout # Check out the code in the project directory
       - check-python # Invoke command "check-python"
       - create-env     
+      - run:
+          # command: | can be used to in a CircleCI config file to run multiple lines of code in a single command
+          command: |
+            echo "Checking current user $USER is able to run docker commands"
+            # Users need to be apart of the docker group to run docker commands with out sudo, try running `usermod -aG docker circleci` to add the current user to the group
+            docker ps 
+          name: Verify current user can use docker
       - run: 
-          command: source ./tools/install.sh
+          command: bash ./tools/install.sh
           name: Run script to install dependencies
       - run:
           command: source ./venv/bin/activate && python3 ./ml/1_build.py # Activate the Python virtual environment before running Python scripts
@@ -60,9 +71,7 @@ jobs:
             - .env # Persist the .env file containing secrets
             - tools # Persist the tools directory
   train:
-    # For running on CircleCI's self-hosted runners - details taken from environment variables
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    executor: runner
     steps: # Steps in jobs are run sequentially
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
@@ -76,9 +85,7 @@ jobs:
           paths:
             - ml # Only files in the ml directory have changed and need to be persisted back to the workspace
   test:
-    # For running on CircleCI's self-hosted runners - details taken from environment variables
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    executor: runner
     steps: # Steps in jobs are run sequentially
       - attach_workspace:
           at: .
@@ -86,9 +93,7 @@ jobs:
           command: source ./venv/bin/activate && python3 ./ml/3_test.py
           name: Test the model
   retrain:
-    # For running on CircleCI's self-hosted runners - details taken from environment variables
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    executor: runner
 
     steps:
       - attach_workspace:
@@ -107,9 +112,7 @@ jobs:
           paths:
             - ml # Only files in the ml directory have changed and need to be persisted back to the workspace
   package:
-    # For running on CircleCI's self-hosted runners - details taken from environment variables
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    executor: runner
 
     steps:
       - attach_workspace:
@@ -118,20 +121,22 @@ jobs:
           command: source ./venv/bin/activate && python3 ./ml/4_package.py
           name: Package the model  
   deploy:
-    # For running on CircleCI's self-hosted runners - details taken from environment variables
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    executor: runner
 
     steps:
       - attach_workspace:
           at: .
       - run:
+          command: |
+            # '\' can be used to continue a long command onto the next line to improve readability
+            docker ps -a | grep "tensorflow_serving" || \
+              docker create --name tensorflow_serving -p 8501:8501 -v /var/models/prod:/models/my_model -e MODEL_NAME=my_model tensorflow/serving
+          name: Ensure server container exists
+      - run:
           command: source ./venv/bin/activate && python3 ./ml/5_deploy.py
           name: Deploy the model
   test-deployment:
-    # For running on CircleCI's self-hosted runners - details taken from environment variables
-    machine: true
-    resource_class: RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS # Update this to reflect your self-hosted runner resource class details
+    executor: runner
     steps:
       - attach_workspace:
           at: .
@@ -146,11 +151,7 @@ workflows:
   # This workflow does a full build from scratch and deploys the model
   build-deploy:
     jobs:
-      - install-build:
-          filters:
-            branches:
-              only:
-                - main # Only run the job when the main branch is updated
+      - install-build
       - train:
           requires: # Only run the job when the preceding step in the ML process has been completed so that they are run sequentially
             - install-build

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ You must set the following[ environment variables](https://circleci.com/docs/env
 
 ### Self-hosted runner details
 
-You will need to update the included CircleCI configuration to replace `RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS` with the details of your own runners.
+You will need to update the included CircleCI configuration to replace `RUNNER_NAMESPACE/RUNNER_RESOURCE_CLASS` with the details of your own runners. The [CircleCI documentation](https://circleci.com/docs/runner-overview/) explains how to install a self-hosted running on many platforms.
 
 ### Using CircleCI
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+# If any of the steps (not in a block construction) fail, the whole script should halt in place and the script will exit with the failure message of the failed step.
+set -eu -o pipefail
 # This script sets up a Python virtual environment and installs the required packages for running the ML workflow scripts in the ml directory
 python3 -m venv ./venv
 source ./venv/bin/activate

--- a/tools/install_server.sh
+++ b/tools/install_server.sh
@@ -1,5 +1,6 @@
-
-#!/bin/bash
+#!/usr/bin/env bash
+# If any of the steps (not in a block construction) fail, the whole script should halt in place and the script will exit with the failure message of the failed step.
+set -eu -o pipefail
 
 #Commands to spin up a quick TensorFlow Serving server for use with this example
 
@@ -16,7 +17,8 @@ sudo chmod -R 775 /var/models
 # docker rm -f tensorflow_serving 
 
 # Create a TensorFlow Serving container with the directories configured for use with this example
-docker run --name tensorflow_serving -p 8501:8501 --mount type=bind,source=/var/models/prod,target=/models/my_model -e MODEL_NAME=my_model tensorflow/serving -d
+# Ensure any previous container is removed first to avoid conflicts and startup errors
+docker run -d -rm --name tensorflow_serving -p 8501:8501 -v /var/models/prod:/models/my_model -e MODEL_NAME=my_model tensorflow/serving
 
 # Until you publish your model to TensorFlow Serving, you will receive this message: Did you forget to name your leaf directory as a number (eg. '/1/')?
 # If you see this message in the Docker output, it means that the container is running successfully

--- a/tools/test_build.sh
+++ b/tools/test_build.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# If any of the steps (not in a block construction) fail, the whole script should halt in place and the script will exit with the failure message of the failed step.
+set -eu -o pipefail
 
 # Runs the build workflow steps for testing purposes
 

--- a/tools/test_retrain.sh
+++ b/tools/test_retrain.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# If any of the steps (not in a block construction) fail, the whole script should halt in place and the script will exit with the failure message of the failed step.
+set -eu -o pipefail
 
 # Runs the retrain workflow for testing purposes
 


### PR DESCRIPTION
#### What does this PR do?
* Modifications to the CircleCI configuration to be more friendly for self-hosted runner environments
* Modifications to scripts to be more friendly for errors in CI environments
* Call on `/usr/bin/env` to discover environment binary instead of hard coding
* Create the deployment container if it does not exist for deployment
* Use `executors` stanza to declare executor to make CI configuration more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
* Link to documentation for installing a self hosted runner in the ReadMe

#### Description of Task to be completed?
* No additional tasks should be needed.

#### How should this be manually tested?
* This can be tested by triggering the CI workflow and monitoring it for successful completion

#### Any background context you want to provide?
* Some small adjustments to make this demo more flexible for different environments when being used with a self hosted runner. 

#### Screenshots (if appropriate)

#### Questions:
